### PR TITLE
speed up rtp by about 16x

### DIFF
--- a/src/main/java/tw/asts/mc/asts/command/Rtp.java
+++ b/src/main/java/tw/asts/mc/asts/command/Rtp.java
@@ -78,14 +78,25 @@ public final class Rtp implements BasicCommand {
         new BukkitRunnable() {
             @Override
             public void run() {
+                int retry = 0;
                 List<Material> unsafeBlocks = List.of(Material.CACTUS, Material.COBWEB, Material.MAGMA_BLOCK, Material.SWEET_BERRY_BUSH);
                 boolean teleported = false;
                 int x = (int) (Math.random() * finalMax * 2) - finalMax;
+                int xinit = x;
                 int z = (int) (Math.random() * finalMax * 2) - finalMax;
                 while(!teleported && stack.getExecutor().isValid()){
                     x+=1;
+                    if (retry>256){
+                        z+=1;
+                        x = xinit;
+                        retry=0;
+                    }
+
+//
+//                    int x = (int) (Math.random() * finalMax * 2) - finalMax;
+//                    int z = (int) (Math.random() * finalMax * 2) - finalMax;
+                    retry++;
                     int y = world.getHighestBlockYAt(x, z);
-                    System.out.println("x: " + x + ", y: " + y + ", z: " + z);
                     if (y < finalMinY) continue;
 
                     if (world.getEnvironment() == World.Environment.NETHER || (args.length == 1 && args[0].equals("cave"))) {

--- a/src/main/java/tw/asts/mc/asts/command/Rtp.java
+++ b/src/main/java/tw/asts/mc/asts/command/Rtp.java
@@ -80,11 +80,12 @@ public final class Rtp implements BasicCommand {
             public void run() {
                 List<Material> unsafeBlocks = List.of(Material.CACTUS, Material.COBWEB, Material.MAGMA_BLOCK, Material.SWEET_BERRY_BUSH);
                 boolean teleported = false;
-                while (!teleported && stack.getExecutor().isValid()) {
-                    int x = (int) (Math.random() * finalMax * 2) - finalMax;
-                    int z = (int) (Math.random() * finalMax * 2) - finalMax;
+                int x = (int) (Math.random() * finalMax * 2) - finalMax;
+                int z = (int) (Math.random() * finalMax * 2) - finalMax;
+                while(!teleported && stack.getExecutor().isValid()){
+                    x+=1;
                     int y = world.getHighestBlockYAt(x, z);
-
+                    System.out.println("x: " + x + ", y: " + y + ", z: " + z);
                     if (y < finalMinY) continue;
 
                     if (world.getEnvironment() == World.Environment.NETHER || (args.length == 1 && args[0].equals("cave"))) {


### PR DESCRIPTION
問題：rtp在大量空氣的時候很慢（終界）
原因：rtp會隨機找位置，但是容易找到空氣，每次都會重新生成新的區域，造成速度減慢（我猜的，大概吧）

解決方法：只random一次然後每次找不到移動一格直到找到

